### PR TITLE
refactor: remove manual UUID boot methods

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Str;
 
 class Course extends Model
 {
@@ -14,17 +13,6 @@ class Course extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 
     public function department(): BelongsTo
     {

--- a/app/Models/Enrollment.php
+++ b/app/Models/Enrollment.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
 
 class Enrollment extends Model
 {
@@ -12,15 +11,4 @@ class Enrollment extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 }

--- a/app/Models/Exam.php
+++ b/app/Models/Exam.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Str;
 
 class Exam extends Model
 {
@@ -14,17 +13,6 @@ class Exam extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 
     public function offering(): BelongsTo
     {

--- a/app/Models/Grade.php
+++ b/app/Models/Grade.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Str;
 
 class Grade extends Model
 {
@@ -13,17 +12,6 @@ class Grade extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 
     public function enrollment(): BelongsTo
     {

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Str;
 
 class Invoice extends Model
 {
@@ -14,17 +13,6 @@ class Invoice extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 
     public function student(): BelongsTo
     {

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Str;
 
 class Payment extends Model
 {
@@ -13,17 +12,6 @@ class Payment extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 
     public function invoice(): BelongsTo
     {

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Str;
 
 class Program extends Model
 {
@@ -14,17 +13,6 @@ class Program extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 
     public function department(): BelongsTo
     {

--- a/app/Models/Scholarship.php
+++ b/app/Models/Scholarship.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Str;
 
 class Scholarship extends Model
 {
@@ -13,17 +12,6 @@ class Scholarship extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 
     public function assignments(): HasMany
     {

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Str;
 
 class Student extends Model
 {
@@ -14,17 +13,6 @@ class Student extends Model
 
     public $incrementing = false;
     protected $keyType = 'string';
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
 
     public function user(): BelongsTo
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,17 +25,6 @@ class User extends Authenticatable
     public $incrementing = false;
     protected $keyType = 'string';
 
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            // Only set a UUID on create (if not already set)
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string)Str::uuid();
-            }
-        });
-    }
-
     protected $fillable = [
         'name',
         'email',


### PR DESCRIPTION
## Summary
- rely on Laravel's HasUuids trait for automatic UUIDs
- keep `$incrementing` and `$keyType` on models

## Testing
- `php -l app/Models/Payment.php`
- `php -l app/Models/Enrollment.php`
- `php -l app/Models/Course.php`
- `php -l app/Models/Grade.php`
- `php -l app/Models/Student.php`
- `php -l app/Models/User.php`
- `php -l app/Models/Exam.php`
- `php -l app/Models/Scholarship.php`
- `php -l app/Models/Program.php`
- `php -l app/Models/Invoice.php`

Composer install failed to complete due to GitHub authentication requirements, so full test suite could not be executed.

------
https://chatgpt.com/codex/tasks/task_e_68bcf71d54e08327986844f56e53666e